### PR TITLE
Add a11y props to icons

### DIFF
--- a/src/icons/IconChild/IconChild.tsx
+++ b/src/icons/IconChild/IconChild.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-export const IconChild = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconChild = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width ?? 24}
     height={props.height ?? 24}
@@ -8,6 +12,10 @@ export const IconChild = (props: React.SVGProps<SVGSVGElement>) => (
     fill="none"
     preserveAspectRatio="xMidYMid meet"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <path

--- a/src/icons/IconClear/IconClear.tsx
+++ b/src/icons/IconClear/IconClear.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconClear = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconClear = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_1760_4613)">

--- a/src/icons/IconDate/IconDate.tsx
+++ b/src/icons/IconDate/IconDate.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconDate = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconDate = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_431_4956)">

--- a/src/icons/IconDropdown/IconDropdown.tsx
+++ b/src/icons/IconDropdown/IconDropdown.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconDropdown = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconDropdown = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_1760_4606)">

--- a/src/icons/IconError/IconError.tsx
+++ b/src/icons/IconError/IconError.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconError = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconError = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_78_3615)">

--- a/src/icons/IconHeart/IconHeart.tsx
+++ b/src/icons/IconHeart/IconHeart.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconHeart = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconHeart = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <path

--- a/src/icons/IconInfo/IconInfo.tsx
+++ b/src/icons/IconInfo/IconInfo.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconInfo = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconInfo = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_110_1404)">

--- a/src/icons/IconLeft/IconLeft.tsx
+++ b/src/icons/IconLeft/IconLeft.tsx
@@ -1,12 +1,21 @@
 import React from "react";
 
-export const IconLeft = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconLeft = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
   width={props.width || 25}
   height={props.height || 24}
     viewBox="2 -1 25 21"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
+    {...props}
   >
     <path
       d="M10 5L5.61326 8.65561C4.77369 9.35526 4.77369 10.6447 5.61326 11.3444L10 15"

--- a/src/icons/IconLock/IconLock.tsx
+++ b/src/icons/IconLock/IconLock.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-export const IconLock = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconLock = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     style={props.style}
     width={props.width || 24}
@@ -8,6 +12,11 @@ export const IconLock = (props: React.SVGProps<SVGSVGElement>) => (
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
+    {...props}
   >
     <path
       fillRule="evenodd"

--- a/src/icons/IconOut/IconOut.tsx
+++ b/src/icons/IconOut/IconOut.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconOut = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconOut = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <path

--- a/src/icons/IconPlus/IconPlus.tsx
+++ b/src/icons/IconPlus/IconPlus.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconPlus = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconPlus = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_110_1353)">

--- a/src/icons/IconPlusInverted/IconPlusInverted.tsx
+++ b/src/icons/IconPlusInverted/IconPlusInverted.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconPlusInverted = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconPlusInverted = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 25 25"
     fill="none"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <path

--- a/src/icons/IconSpinner/IconSpinner.tsx
+++ b/src/icons/IconSpinner/IconSpinner.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconSpinner = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconSpinner = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <mask

--- a/src/icons/IconSuccess/IconSuccess.tsx
+++ b/src/icons/IconSuccess/IconSuccess.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconSuccess = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconSuccess = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <g clipPath="url(#clip0_78_3680)">

--- a/src/icons/IconTime/IconTime.tsx
+++ b/src/icons/IconTime/IconTime.tsx
@@ -1,12 +1,20 @@
 import type { SVGProps } from "react";
 
-export const IconTime = (props: SVGProps<SVGSVGElement>) => (
+export const IconTime = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={props.width ?? 24}
     height={props.height ?? 24}
     viewBox="0 0 24 24"
     fill="none"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <path

--- a/src/icons/IconUser/IconUser.tsx
+++ b/src/icons/IconUser/IconUser.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconUser = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconUser = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width={props.width || 24}
     height={props.height || 24}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <rect

--- a/src/icons/IconX/IconX.tsx
+++ b/src/icons/IconX/IconX.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 
-export const IconX = (props: React.SVGProps<SVGSVGElement>) => (
+export const IconX = ({
+  "aria-label": ariaLabel,
+  role,
+  ...props
+}: React.SVGProps<SVGSVGElement>) => (
   <svg
     width="24"
     height="24"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    role={ariaLabel ? (role ?? "img") : (role ?? "presentation")}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : true}
+    focusable="false"
     {...props}
   >
     <path


### PR DESCRIPTION
## Summary
- improve accessibility for all icons

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7a71e5ac83239074738a575dd574