### PR TITLE
Add ref forwarding for focusable inputs

### DIFF
--- a/src/components/FormItems/Checkbox/Checkbox.tsx
+++ b/src/components/FormItems/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { memo, InputHTMLAttributes } from "react";
+import React, { memo, InputHTMLAttributes, forwardRef } from "react";
 import { Wrapper, InputWrapper } from "./style";
 import { ErrorMessage, StyledLabel } from "../Input/style";
 
@@ -9,6 +9,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const Checkbox = memo(
+  forwardRef<HTMLInputElement, CheckboxProps>(
   ({
     style,
     checked,
@@ -18,7 +19,7 @@ export const Checkbox = memo(
     errorMessage,
     disabled,
     ...rest
-  }: CheckboxProps) => {
+  }: CheckboxProps, ref) => {
     const errorId = errorMessage ? `${name}-error` : undefined;
 
     return (
@@ -26,6 +27,7 @@ export const Checkbox = memo(
         <Wrapper>
           <InputWrapper style={style}>
             <input
+              ref={ref}
               name={name}
               id={name}
               disabled={disabled}
@@ -48,7 +50,7 @@ export const Checkbox = memo(
         )}
       </>
     );
-  }
-);
+    });
+  );
 
 export default Checkbox;

--- a/src/components/FormItems/DateInput/DateInput.tsx
+++ b/src/components/FormItems/DateInput/DateInput.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useId } from "react";
+import { memo, useMemo, useId, forwardRef } from "react";
 import dayjs from "dayjs";
 import type { Dayjs } from "dayjs";
 import "dayjs/locale/ru";
@@ -26,6 +26,7 @@ export type DateInputProps = {
 };
 
 export const DateInput = memo(
+  forwardRef<any, DateInputProps>(
   ({
     label,
     errorMessage,
@@ -33,7 +34,7 @@ export const DateInput = memo(
     value = null,
     onChange,
     required,
-  }: DateInputProps) => {
+  }: DateInputProps, ref) => {
     const dateValue = useMemo(
       () => (value ? dayjs(value, "DD.MM.YYYY") : null),
       [value]
@@ -59,6 +60,7 @@ export const DateInput = memo(
 
         <InputWrapper>
           <StyledDatePicker
+            ref={ref}
             id={inputId}
             locale={locale}
             popupClassName="mts-datepicker-popup"
@@ -83,5 +85,5 @@ export const DateInput = memo(
         )}
       </Wrapper>
     );
-  }
+  });
 );

--- a/src/components/FormItems/Input/Input.tsx
+++ b/src/components/FormItems/Input/Input.tsx
@@ -1,4 +1,13 @@
-import { memo, InputHTMLAttributes, useState, useEffect, useRef, useId } from "react";
+import {
+  memo,
+  InputHTMLAttributes,
+  useState,
+  useEffect,
+  useRef,
+  useId,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import {
   StyledInput,
   ErrorMessage,
@@ -20,16 +29,20 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 };
 
 export const Input = memo(
-  ({
-    errorMessage = null,
-    validatePattern,
-    onBlur,
-    onChange,
-    label,
-    id,
-    disabled,
-    ...props
-  }: InputProps) => {
+  forwardRef<HTMLInputElement, InputProps>(
+    (
+      {
+        errorMessage = null,
+        validatePattern,
+        onBlur,
+        onChange,
+        label,
+        id,
+        disabled,
+        ...props
+      }: InputProps,
+      ref,
+    ) => {
     const [error, setError] = useState<string | null>(errorMessage || null);
     const generatedId = useId();
     const inputId = id || `input-${generatedId}`;
@@ -41,6 +54,7 @@ export const Input = memo(
     };
 
     const inputRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => inputRef.current as HTMLInputElement | null);
 
     const handleClear = () => {
       if (disabled) return;
@@ -118,7 +132,7 @@ export const Input = memo(
         {error && <ErrorMessage id={errorId}>{error}</ErrorMessage>}
       </Wrapper>
     );
-  }
+  });
 );
 
 export default Input;

--- a/src/components/FormItems/RadioButton/RadioButton.tsx
+++ b/src/components/FormItems/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React, { memo, InputHTMLAttributes, useId } from "react";
+import React, { memo, InputHTMLAttributes, useId, forwardRef } from "react";
 import { Wrapper, InputWrapper, Label } from "./style";
 import { ErrorMessage, StyledLabel } from "../Input/style";
 
@@ -10,6 +10,7 @@ export interface RadioButtonProps
 }
 
 export const RadioButton = memo(
+  forwardRef<HTMLInputElement, RadioButtonProps>(
   ({
     style,
     checked,
@@ -19,7 +20,7 @@ export const RadioButton = memo(
     value,
     errorMessage,
     disabled,
-  }: RadioButtonProps) => {
+  }: RadioButtonProps, ref) => {
     const generatedId = useId();
     const id = `${name}-${value}-${generatedId}`;
     const errorId = `${id}-error`;
@@ -33,6 +34,7 @@ export const RadioButton = memo(
         >
           <InputWrapper style={style}>
             <input
+              ref={ref}
               name={name}
               id={id}
               disabled={disabled}
@@ -71,8 +73,8 @@ export const RadioButton = memo(
           <ErrorMessage id={errorId}>{errorMessage}</ErrorMessage>
         )}
       </>
-    );
-  }
-);
+      );
+    });
+  );
 
 export default RadioButton;

--- a/src/components/FormItems/Select/Select.tsx
+++ b/src/components/FormItems/Select/Select.tsx
@@ -1,5 +1,5 @@
-import React, { useId } from "react";
-import ReactSelect, { StylesConfig } from "react-select";
+import React, { useId, forwardRef } from "react";
+import ReactSelect, { StylesConfig, type SelectInstance } from "react-select";
 import { Wrapper } from "./style";
 import IconLock from "../../../icons/IconLock/IconLock";
 import {
@@ -39,7 +39,7 @@ export interface SelectProps {
   rsProps?: Record<string, unknown>;
 }
 
-export const Select: React.FC<SelectProps> = ({
+export const Select = forwardRef<SelectInstance, SelectProps>(({ 
   name,
   value,
   onChange,
@@ -52,7 +52,7 @@ export const Select: React.FC<SelectProps> = ({
   rsProps,
   id,
   required,
-}) => {
+}, ref) => {
   const generatedId = useId();
   const selectId = id || `select-${generatedId}`;
   const errorId = `${selectId}-error`;
@@ -141,6 +141,7 @@ export const Select: React.FC<SelectProps> = ({
       )}
 
       <ReactSelect
+        ref={ref}
         inputId={selectId}
         instanceId={name}
         isDisabled={disabled}
@@ -176,7 +177,6 @@ export const Select: React.FC<SelectProps> = ({
 
       {error && <ErrorMessage id={errorId}>{error}</ErrorMessage>}
     </Wrapper>
-  );
-};
+});
 
 export default Select;

--- a/src/components/FormItems/TimeInput/TimeInput.tsx
+++ b/src/components/FormItems/TimeInput/TimeInput.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, forwardRef } from "react";
 import { TimePicker } from "antd";
 import dayjs from "dayjs";
 import type { Dayjs } from "dayjs";
@@ -24,6 +24,7 @@ export type TimeInputProps = {
 };
 
 export const TimeInput = memo(
+  forwardRef<any, TimeInputProps>(
   ({
     inputId,
     label,
@@ -32,7 +33,7 @@ export const TimeInput = memo(
     value = null,
     onChange,
     required,
-  }: TimeInputProps) => {
+  }: TimeInputProps, ref) => {
     const timeValue = useMemo(
       () => (value ? dayjs(value, "HH:mm") : null),
       [value]
@@ -49,6 +50,7 @@ export const TimeInput = memo(
         )}
         <InputWrapper>
           <StyledTimePicker
+            ref={ref}
             id={inputId}
             placeholder="чч:мм"
             value={timeValue}
@@ -69,5 +71,5 @@ export const TimeInput = memo(
         )}
       </Wrapper>
     );
-  }
+  });
 );


### PR DESCRIPTION
## Summary
- forward refs through `Input`, `Checkbox`, `RadioButton`, `Select`, `DateInput` and `TimeInput`

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e90f45a0c83238c449c716c80659a